### PR TITLE
update: referral contract interface to pass sponsored

### DIFF
--- a/src/interface/referral.cairo
+++ b/src/interface/referral.cairo
@@ -4,6 +4,6 @@ from starkware.cairo.common.uint256 import Uint256
 @contract_interface
 namespace Referral {
     // View functions
-    func add_commission(amount: Uint256, sponsor_addr: felt) {
+    func add_commission(amount: Uint256, sponsor_addr: felt, sponsored_addr : felt) {
     }
 }

--- a/src/naming/registration.cairo
+++ b/src/naming/registration.cairo
@@ -69,7 +69,8 @@ func pay_buy_domain{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_
 
     if (sponsor != 0) {
         let (referral_contract) = _referral_contract.read();
-        Referral.add_commission(referral_contract, price, sponsor);
+        let (sponsored) = get_caller_address();
+        Referral.add_commission(referral_contract, price, sponsor, sponsored);
         return ();
     }
 
@@ -100,7 +101,8 @@ func pay_renew_domain{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_chec
 
     if (sponsor != 0) {
         let (referral_contract) = _referral_contract.read();
-        Referral.add_commission(referral_contract, price, sponsor);
+        let (sponsored) = get_caller_address();
+        Referral.add_commission(referral_contract, price, sponsor, sponsored);
         return ();
     }
 


### PR DESCRIPTION
This pull request updates naming contract to support new referral interface. This closes #48 

We need to first deploy referral, then set it and update the contract. There will be a down time between those two calls. It might be a good idea to do a multicall for it.