### PR TITLE
ref: update identity interface

### DIFF
--- a/src/interface/starknetid.cairo
+++ b/src/interface/starknetid.cairo
@@ -10,10 +10,10 @@ namespace StarknetId {
     func owner_of(token_id) -> (owner: felt) {
     }
 
-    func get_verifier_data(token_id, field, verifier) -> (data: felt) {
+    func get_verifier_data(token_id, field, verifier, domain) -> (data: felt) {
     }
 
-    func set_verifier_data(token_id, field, data) {
+    func set_verifier_data(token_id, field, data, domain) {
     }
 
 }

--- a/src/naming/main.cairo
+++ b/src/naming/main.cairo
@@ -378,8 +378,8 @@ func transfer_domain{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check
         );
         _domain_data.write(hashed_domain, new_domain_data);
         domain_transfer.emit(domain_len, domain, current_domain_data.owner, target_token_id);
-        StarknetId.set_verifier_data(contract, current_domain_data.owner, 'name', 0);
-        StarknetId.set_verifier_data(contract, target_token_id, 'name', hashed_domain);
+        StarknetId.set_verifier_data(contract, current_domain_data.owner, 'name', 0, 0);
+        StarknetId.set_verifier_data(contract, target_token_id, 'name', hashed_domain, 0);
         return ();
     } else {
         let (hashed_parent_domain) = hash_domain(domain_len - 1, domain + 1);
@@ -394,8 +394,8 @@ func transfer_domain{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check
         );
         _domain_data.write(hashed_domain, new_domain_data);
         domain_transfer.emit(domain_len, domain, current_domain_data.owner, target_token_id);
-        StarknetId.set_verifier_data(contract, current_domain_data.owner, 'name', 0);
-        StarknetId.set_verifier_data(contract, target_token_id, 'name', hashed_domain);
+        StarknetId.set_verifier_data(contract, current_domain_data.owner, 'name', 0, 0);
+        StarknetId.set_verifier_data(contract, target_token_id, 'name', hashed_domain, 0);
         return ();
     }
 }
@@ -460,8 +460,8 @@ func set_domain_owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_chec
     _domain_data.write(hashed_domain, new_domain_data);
     domain_transfer.emit(domain_len, domain, current_domain_data.owner, token_id);
     let (contract) = starknetid_contract.read();
-    StarknetId.set_verifier_data(contract, current_domain_data.owner, 'name', 0);
-    StarknetId.set_verifier_data(contract, token_id, 'name', hashed_domain);
+    StarknetId.set_verifier_data(contract, current_domain_data.owner, 'name', 0, 0);
+    StarknetId.set_verifier_data(contract, token_id, 'name', hashed_domain, 0);
 
     return ();
 }

--- a/src/naming/registration.cairo
+++ b/src/naming/registration.cairo
@@ -118,7 +118,7 @@ func mint_domain{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
     starknet_id_update.emit(1, new (domain), token_id, expiry);
     domain_to_addr_update.emit(1, new (domain), target_address);
     let (contract) = starknetid_contract.read();
-    StarknetId.set_verifier_data(contract, token_id, 'name', hashed_domain);
+    StarknetId.set_verifier_data(contract, token_id, 'name', hashed_domain, 0);
     if (resolver != 0) {
         domain_to_resolver_update.emit(1, new(domain), resolver);
     }
@@ -186,7 +186,7 @@ func assert_empty_starknet_id{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ra
 ) {
     let (contract_addr) = starknetid_contract.read();
     let (sid_hashed_domain) = StarknetId.get_verifier_data(
-        contract_addr, starknet_id, 'name', naming_contract
+        contract_addr, starknet_id, 'name', naming_contract, 0
     );
 
     with_attr error_message("This starknet_id already has a domain") {


### PR DESCRIPTION
This PR updates the `identity` interface, and the `get` and `set` verifier data functions to match the new interface.